### PR TITLE
Use return await in maybeInstantiateStreaming

### DIFF
--- a/content/things/raw-wasm.md
+++ b/content/things/raw-wasm.md
@@ -119,7 +119,7 @@ The compilation of a WebAssembly module can start even when the module is still 
 
       // This will throw either if `instantiateStreaming` is
       // undefined or the `Content-Type` header is wrong.
-      return WebAssembly.instantiateStreaming(
+      return await WebAssembly.instantiateStreaming(
         f,
         ...opts
       );


### PR DESCRIPTION
[As previously suggested on Twitter](https://twitter.com/MattiasBuelens/status/1129523629904080896): this makes `maybeInstantiateStreaming` properly catch async errors, such as an incorrect `Content-Type` header.. 😉