### PR TITLE
Update codeblock padding

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -305,7 +305,6 @@ pre > code,
   width: 100%;
   overflow-x: auto;
   padding-left: calc(50vw - var(--width) / 2);
-  padding-right: calc(50vw - var(--width) / 2);
   font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
 }
 blockquote {


### PR DESCRIPTION
When viewing code blocks that exceed the '--width' variable in the css, a horizontal scrollbar will appear - even if there is enough room to view the entire block on screen.

By removing the padding on the right, the block will not become larger than the box until it is too big for the screen.

![an example from react-redux-comlink](https://user-images.githubusercontent.com/13655076/73247953-5eb5ff00-41f5-11ea-9c5a-ed70da48edca.png)