### PR TITLE
Improve font rendering in Firefox

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -81,6 +81,7 @@ body {
   background-color: var(--yellow);
   color: var(--darkblue);
   font-family: "Vinila", "Helvetica", sans-serif;
+  font-synthesis: none; /* Make the below render more nicely in Firefox */
   font-variation-settings: "wdth" var(--body-font-width),
     "wght" var(--body-font-weight), "slnt" var(--body-font-slant);
   font-size: var(--grid-height);


### PR DESCRIPTION
Right now, Firefox applies additional bolding on top of the weight applied via `font-variation-settings`, and likewise for italics. This makes the cool heading font get kind of smeary and indistinct, and the italics lean about twice as much as intended.

With `font-synthesis: none`, Firefox’s rendering looks like other browsers’.