### PR TITLE
Updated for recent WebGPU syntax changes

### DIFF
--- a/static/things/webgpu/step1/main.js
+++ b/static/things/webgpu/step1/main.js
@@ -14,9 +14,9 @@ if (!device) fatal("Couldn’t request WebGPU device.");
 const module = device.createShaderModule({
   code: `
     @group(0) @binding(1)
-    var<storage, write> output: array<f32>;
+    var<storage, read_write> output: array<f32>;
 
-    @stage(compute) @workgroup_size(64)
+    @compute @workgroup_size(64)
     fn main(
       @builtin(global_invocation_id)
       global_id : vec3<u32>,
@@ -81,7 +81,7 @@ const commandEncoder = device.createCommandEncoder();
 const passEncoder = commandEncoder.beginComputePass();
 passEncoder.setPipeline(pipeline);
 passEncoder.setBindGroup(0, bindGroup);
-passEncoder.dispatch(Math.ceil(BUFFER_SIZE / 64));
+passEncoder.dispatchWorkgroups(Math.ceil(BUFFER_SIZE / 64));
 passEncoder.end();
 commandEncoder.copyBufferToBuffer(output, 0, stagingBuffer, 0, BUFFER_SIZE);
 const commands = commandEncoder.finish();

--- a/static/things/webgpu/step2/main.js
+++ b/static/things/webgpu/step2/main.js
@@ -14,15 +14,15 @@ if (!device) fatal("Couldn’t request WebGPU device.");
 const module = device.createShaderModule({
   code: `
     struct Ball {
-      radius: f32;
-      position: vec2<f32>;
-      velocity: vec2<f32>;
+      radius: f32,
+      position: vec2<f32>,
+      velocity: vec2<f32>,
     }
 
     @group(0) @binding(1)
-    var<storage, write> output: array<Ball>;
+    var<storage, read_write> output: array<Ball>;
 
-    @stage(compute) @workgroup_size(64)
+    @compute @workgroup_size(64)
     fn main(
 
       @builtin(global_invocation_id)
@@ -93,7 +93,7 @@ const commandEncoder = device.createCommandEncoder();
 const passEncoder = commandEncoder.beginComputePass();
 passEncoder.setPipeline(pipeline);
 passEncoder.setBindGroup(0, bindGroup);
-passEncoder.dispatch(Math.ceil(BUFFER_SIZE / 64));
+passEncoder.dispatchWorkgroups(Math.ceil(BUFFER_SIZE / 64));
 passEncoder.end();
 commandEncoder.copyBufferToBuffer(output, 0, stagingBuffer, 0, BUFFER_SIZE);
 const commands = commandEncoder.finish();

--- a/static/things/webgpu/step3/main.js
+++ b/static/things/webgpu/step3/main.js
@@ -16,20 +16,20 @@ if (!device) fatal("Couldn’t request WebGPU device.");
 const module = device.createShaderModule({
   code: `
     struct Ball {
-      radius: f32;
-      position: vec2<f32>;
-      velocity: vec2<f32>;
+      radius: f32,
+      position: vec2<f32>,
+      velocity: vec2<f32>,
     }
 
     @group(0) @binding(0)
     var<storage, read> input: array<Ball>;
 
     @group(0) @binding(1)
-    var<storage, write> output: array<Ball>;
+    var<storage, read_write> output: array<Ball>;
 
-    let TIME_STEP: f32 = 0.016;
+    const TIME_STEP: f32 = 0.016;
 
-    @stage(compute) @workgroup_size(64)
+    @compute @workgroup_size(64)
     fn main(
       @builtin(global_invocation_id)
       global_id : vec3<u32>,
@@ -135,7 +135,7 @@ while (true) {
   passEncoder.setPipeline(pipeline);
   passEncoder.setBindGroup(0, bindGroup);
   const dispatchSize = Math.ceil(NUM_BALLS / 64);
-  passEncoder.dispatch(dispatchSize);
+  passEncoder.dispatchWorkgroups(dispatchSize);
   passEncoder.end();
   commandEncoder.copyBufferToBuffer(output, 0, stagingBuffer, 0, BUFFER_SIZE);
   const commands = commandEncoder.finish();

--- a/static/things/webgpu/step4/main.js
+++ b/static/things/webgpu/step4/main.js
@@ -31,29 +31,29 @@ if (!device) fatal("Couldn’t request WebGPU device.");
 const module = device.createShaderModule({
   code: `
     struct Ball {
-      radius: f32;
-      position: vec2<f32>;
-      velocity: vec2<f32>;
+      radius: f32,
+      position: vec2<f32>,
+      velocity: vec2<f32>,
     }
 
     @group(0) @binding(0)
     var<storage, read> input: array<Ball>;
 
     @group(0) @binding(1)
-    var<storage, write> output: array<Ball>;
+    var<storage, read_write> output: array<Ball>;
 
     struct Scene {
-      width: f32;
-      height: f32;
+      width: f32,
+      height: f32,
     }
 
     @group(0) @binding(2)
     var<storage, read> scene: Scene;
 
-    let PI: f32 = 3.14159;
-    let TIME_STEP: f32 = 0.016;
+    const PI: f32 = 3.14159;
+    const TIME_STEP: f32 = 0.016;
 
-    @stage(compute) @workgroup_size(64)
+    @compute @workgroup_size(64)
     fn main(
       @builtin(global_invocation_id)
       global_id : vec3<u32>,
@@ -221,7 +221,7 @@ while (true) {
   passEncoder.setPipeline(pipeline);
   passEncoder.setBindGroup(0, bindGroup);
   const dispatchSize = Math.ceil(NUM_BALLS / 64);
-  passEncoder.dispatch(dispatchSize);
+  passEncoder.dispatchWorkgroups(dispatchSize);
   passEncoder.end();
   commandEncoder.copyBufferToBuffer(output, 0, stagingBuffer, 0, BUFFER_SIZE);
   const commands = commandEncoder.finish();


### PR DESCRIPTION
Gets the demos working in Chrome Canary

 - `@stage(compute)` -> `@compute`
 - `dispatch()` -> `dispatchWorkgroups()`
 - `var<storage, write>` -> `var<storage, read_write>`
 - static globals used `const` instead of `let`
 - Struct members separated by `,` instead of `;`